### PR TITLE
View-Data-Dot-Notation-Keys

### DIFF
--- a/Engine/Modules/TemplateEngine/Core/Manager/TemplateManager.php
+++ b/Engine/Modules/TemplateEngine/Core/Manager/TemplateManager.php
@@ -2,16 +2,30 @@
 
 namespace Oforge\Engine\Modules\TemplateEngine\Core\Manager;
 
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 use Oforge\Engine\Modules\Core\Abstracts\AbstractTemplateManager;
+use Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException;
+use Oforge\Engine\Modules\Core\Exceptions\TemplateNotFoundException;
 use Oforge\Engine\Modules\Core\Helper\Helper;
 use Oforge\Engine\Modules\Core\Helper\Statics;
+use Oforge\Engine\Modules\TemplateEngine\Core\Exceptions\InvalidScssVariableException;
 use Oforge\Engine\Modules\TemplateEngine\Core\Services\TemplateManagementService;
 use Oforge\Engine\Modules\TemplateEngine\Core\Services\TemplateRenderService;
 use Psr\Http\Message\ResponseInterface;
 use Slim\Http\Request;
 use Slim\Http\Response;
+use Twig_Error_Loader;
+use Twig_Error_Runtime;
+use Twig_Error_Syntax;
 
+/**
+ * Class TemplateManager
+ *
+ * @package Oforge\Engine\Modules\TemplateEngine\Core\Manager
+ */
 class TemplateManager extends AbstractTemplateManager {
+    /** @var TemplateManager $instance */
     protected static $instance;
 
     /**
@@ -19,7 +33,7 @@ class TemplateManager extends AbstractTemplateManager {
      *
      * @return TemplateManager
      */
-    public static function getInstance() {
+    public static function getInstance() : TemplateManager {
         if (!isset(self::$instance)) {
             self::$instance = new TemplateManager();
         }
@@ -30,16 +44,14 @@ class TemplateManager extends AbstractTemplateManager {
     /**
      * Initialize and configure the TemplateManager.
      *
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException
-     * @throws \Oforge\Engine\Modules\TemplateEngine\Core\Exceptions\InvalidScssVariableException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\TemplateNotFoundException
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws ServiceNotFoundException
+     * @throws InvalidScssVariableException
+     * @throws TemplateNotFoundException
      */
     public function init() {
-        /**
-         * @var $templateManagementService TemplateManagementService
-         */
+        /** @var TemplateManagementService $templateManagementService */
         $templateManagementService = Oforge()->Services()->get("template.management");
 
         $templateFiles = Helper::getTemplateFiles(ROOT_PATH . DIRECTORY_SEPARATOR . Statics::TEMPLATE_DIR);
@@ -61,23 +73,22 @@ class TemplateManager extends AbstractTemplateManager {
      *
      * @param Request $request
      * @param Response $response
-     * @param $data
+     * @param array $data
      *
      * @return ResponseInterface|Response
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\TemplateNotFoundException
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws ServiceNotFoundException
+     * @throws TemplateNotFoundException
+     * @throws Twig_Error_Loader
+     * @throws Twig_Error_Runtime
+     * @throws Twig_Error_Syntax
      */
-    public function render(Request $request, Response $response, $data) {
-        /**
-         * @var $templateRenderService TemplateRenderService
-         */
+    public function render(Request $request, Response $response, array $data) {
+        /** @var TemplateRenderService $templateRenderService */
         $templateRenderService = Oforge()->Services()->get("template.render");
 
         return $templateRenderService->render($request, $response, $data);
     }
+
 }

--- a/Engine/Modules/TemplateEngine/Core/Manager/ViewManager.php
+++ b/Engine/Modules/TemplateEngine/Core/Manager/ViewManager.php
@@ -51,6 +51,7 @@ class ViewManager extends AbstractViewManager {
      * @return ViewManager
      */
     public function assign($data) {
+        $data           = ArrayHelper::dotToNested($data);
         $this->viewData = ArrayHelper::mergeRecursive($this->viewData, $data);
 
         return $this;
@@ -67,22 +68,26 @@ class ViewManager extends AbstractViewManager {
     }
 
     /**
-     * Get a specific key value from the viewData
+     * Get a specific key value from the viewData or $default if data with key does not exist.
      *
      * @param string $key
+     * @param mixed $default
      *
-     * @return int
+     * @return mixed|null
      */
-    public function get(string $key) {
-        return key_exists($key, $this->viewData) ? $this->viewData[$key] : null;
+    public function get(string $key, $default = null) {
+        return ArrayHelper::dotGet($this->viewData, $key, $default);
     }
 
     /**
+     * Exist non empty value with key?
+     *
      * @param string $key
      *
      * @return bool
      */
-    public function has(string $key) {
+    public function has(string $key) : bool {
         return isset($this->viewData[$key]) && !empty($this->viewData[$key]);
     }
+
 }

--- a/Engine/Modules/TemplateEngine/Core/Services/TemplateRenderService.php
+++ b/Engine/Modules/TemplateEngine/Core/Services/TemplateRenderService.php
@@ -8,19 +8,31 @@
 
 namespace Oforge\Engine\Modules\TemplateEngine\Core\Services;
 
-use Doctrine\ORM\Query\AST\Functions\DateSubFunction;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException;
 use Oforge\Engine\Modules\Core\Exceptions\TemplateNotFoundException;
+use Oforge\Engine\Modules\Core\Helper\ArrayHelper;
 use Oforge\Engine\Modules\Core\Helper\Statics;
 use Oforge\Engine\Modules\Core\Models\Plugin\Plugin;
 use Oforge\Engine\Modules\TemplateEngine\Core\Twig\CustomTwig;
+use Oforge\Engine\Modules\TemplateEngine\Core\Twig\TwigOforgeDebugExtension;
 use Psr\Http\Message\ResponseInterface;
 use Slim\Http\Request;
 use Slim\Http\Response;
+use Twig_Error_Loader;
+use Twig_Error_Runtime;
+use Twig_Error_Syntax;
 use Twig_Extension_Debug;
 use Twig_Loader_Filesystem;
-use Oforge\Engine\Modules\TemplateEngine\Core\Twig\TwigOforgeDebugExtension;
 
+/**
+ * Class TemplateRenderService
+ *
+ * @package Oforge\Engine\Modules\TemplateEngine\Core\Services
+ */
 class TemplateRenderService {
+    const TWIG_MAIN_NAMESPACE = Twig_Loader_Filesystem::MAIN_NAMESPACE;
     /**
      * @var $view CustomTwig
      */
@@ -37,55 +49,53 @@ class TemplateRenderService {
      * @param $data
      *
      * @return ResponseInterface|Response
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws ServiceNotFoundException
+     * @throws Twig_Error_Loader
+     * @throws Twig_Error_Runtime
+     * @throws Twig_Error_Syntax
      * @throws TemplateNotFoundException
      */
     public function render(Request $request, Response $response, $data) {
-        if (isset($data["json"]) && is_array($data["json"])) {
-            return $this->renderJson($request, $response, $data["json"]);
+        if (isset($data['json']) && is_array($data['json'])) {
+            return $this->renderJson($request, $response, $data['json']);
         } else {
-            $routeController = Oforge()->View()->get('meta')['route'];
-            $namespace  = explode("\\", $routeController['controllerClass']);
-
-            $foundController = false;
-            $index           = 0;
-            $size            = sizeof($namespace);
-            $templatePath    = null;
-
-            // register all modules
-            foreach ($namespace as $key) {
-                if($index == 0 && $key !== "Oforge") {
-                    $templatePath = DIRECTORY_SEPARATOR . "Plugins" . DIRECTORY_SEPARATOR . $key;
-                }
-                if ($foundController && $index + 1 !== $size) {
-                    $templatePath .= DIRECTORY_SEPARATOR . $key;
-                }
-
-                if ($key == "Controller") {
-                    $foundController = true;
-                }
-                $index++;
-            }
-
-
-            $controllerName = explode("Controller", explode(":", $namespace[sizeof($namespace) - 1])[0])[0];
-            $fileName       = explode("Action", $routeController['controllerMethod'])[0];
-
-            $templatePath .= DIRECTORY_SEPARATOR . $controllerName . DIRECTORY_SEPARATOR . ucwords($fileName) . ".twig";
-
-            if (isset($data["template"]["path"])) {
-                $templatePath = $data["template.path"];
+            if (isset($data['meta']['template']['path'])) {
+                $templatePath = $data['meta']['template']['path'];
             } else {
-                $data["template.path"] = $templatePath;
+                $routeController = Oforge()->View()->get('meta.route');
+                $namespace       = explode("\\", $routeController['controllerClass']);
+                $controllerName  = explode('Controller', $namespace[sizeof($namespace) - 1])[0];
+                $fileName        = explode('Action', $routeController['controllerMethod'])[0];
+
+                $foundController = false;
+                $index           = 0;
+                $size            = count($namespace);
+                $templatePath    = null;
+
+                // register all modules
+                foreach ($namespace as $key) {
+                    if ($index === 0 && $key !== 'Oforge') {
+                        $templatePath = DIRECTORY_SEPARATOR . 'Plugins' . DIRECTORY_SEPARATOR . $key;
+                    }
+                    if ($foundController && ($index + 1 !== $size)) {
+                        $templatePath .= DIRECTORY_SEPARATOR . $key;
+                    }
+
+                    if ($key === 'Controller') {
+                        $foundController = true;
+                    }
+                    $index++;
+                }
+
+                $templatePath .= DIRECTORY_SEPARATOR . $controllerName . DIRECTORY_SEPARATOR . ucwords($fileName) . '.twig';
+
+                $data = ArrayHelper::dotSet($data, 'meta.template.path', $templatePath);
             }
 
-            if (!isset($data["template_layout"])) {
-                $data["template_layout"] = "Default";
+            if (!isset($data['meta']['template']['layout'])) {
+                $data['meta']['template']['layout'] = 'Default';
             }
 
             if ($this->hasTemplate($templatePath)) {
@@ -97,63 +107,13 @@ class TemplateRenderService {
     }
 
     /**
-     * Send a JSON response
-     *
-     * @param Request $request
-     * @param Response $response
-     * @param $data
-     *
-     * @return Response
-     */
-    private function renderJson(Request $request, Response $response, $data) {
-        return $response->withHeader('Content-Type', 'application/json')->withJson($data);
-    }
-
-    /**
-     * Send the response through the Twig Engine
-     *
-     * @param Request $request
-     * @param Response $response
-     * @param string $template
-     * @param $data
-     *
-     * @return ResponseInterface
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
-     * @throws TemplateNotFoundException
-     */
-    private function renderTemplate(Request $request, Response $response, string $template, $data) {
-        return $this->View()->render($response, $template, $data);
-    }
-
-    /**
-     * Check if the template exists
-     *
-     * @param $template
-     *
-     * @return bool
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException
-     * @throws \Twig_Error_Loader
-     * @throws TemplateNotFoundException
-     */
-    private function hasTemplate($template) : bool {
-        return $this->View()->hasTemplate($template);
-    }
-
-    /**
      * If no Twig Engine is loaded, create one
      *
      * @return CustomTwig
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException
-     * @throws \Twig_Error_Loader
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws ServiceNotFoundException
+     * @throws Twig_Error_Loader
      * @throws TemplateNotFoundException
      */
     public function View() {
@@ -162,37 +122,37 @@ class TemplateRenderService {
             $templateManagementService = Oforge()->Services()->get('template.management');
             $activeTemplate            = $templateManagementService->getActiveTemplate();
             $templatePath              = DIRECTORY_SEPARATOR . Statics::TEMPLATE_DIR . DIRECTORY_SEPARATOR . $activeTemplate->getName();
-            $debug                     = Oforge()->Settings()->get("mode") == "development";
+            $debug                     = Oforge()->Settings()->isDevelopmentMode();
+            $defaultThemePath          = ROOT_PATH . DIRECTORY_SEPARATOR . Statics::TEMPLATE_DIR . DIRECTORY_SEPARATOR . Statics::DEFAULT_THEME;
 
-            /** @var $plugins Plugin[] */
-            $plugins = Oforge()->Services()->get("plugin.access")->getActive();
-            $paths   = [];
+            /** @var Plugin[] $plugins */
+            $plugins = Oforge()->Services()->get('plugin.access')->getActive();
+            $paths   = [
+                'parent'                  => [],
+                self::TWIG_MAIN_NAMESPACE => [],
+            ];
 
-            $paths[Twig_Loader_Filesystem::MAIN_NAMESPACE] = [];
             if ($activeTemplate->getName() !== Statics::DEFAULT_THEME) {
-                $paths[Twig_Loader_Filesystem::MAIN_NAMESPACE] = [ROOT_PATH . DIRECTORY_SEPARATOR . $templatePath];
+                $paths[self::TWIG_MAIN_NAMESPACE] = [ROOT_PATH . DIRECTORY_SEPARATOR . $templatePath];
             }
-            $paths["parent"] = [];
 
             foreach ($plugins as $plugin) {
                 $viewsDir = ROOT_PATH . DIRECTORY_SEPARATOR . Statics::PLUGIN_DIR . DIRECTORY_SEPARATOR . $plugin->getName() . DIRECTORY_SEPARATOR
                             . Statics::VIEW_DIR;
 
                 if (file_exists($viewsDir)) {
-                    array_push($paths["parent"], $viewsDir);
-                    array_push($paths[Twig_Loader_Filesystem::MAIN_NAMESPACE], $viewsDir);
+                    $paths['parent'][]                  = $viewsDir;
+                    $paths[self::TWIG_MAIN_NAMESPACE][] = $viewsDir;
 
-                    if (!array_key_exists($plugin->getName(), $paths)) {
+                    if (!isset($paths[$plugin->getName()])) {
                         $paths[$plugin->getName()] = [];
                     }
-
-                    array_push($paths[$plugin->getName()], $viewsDir);
+                    $paths[$plugin->getName()][] = $viewsDir;
                 }
             }
 
-            array_push($paths["parent"], ROOT_PATH . DIRECTORY_SEPARATOR . Statics::TEMPLATE_DIR . DIRECTORY_SEPARATOR . Statics::DEFAULT_THEME);
-            array_push($paths[Twig_Loader_Filesystem::MAIN_NAMESPACE],
-                ROOT_PATH . DIRECTORY_SEPARATOR . Statics::TEMPLATE_DIR . DIRECTORY_SEPARATOR . Statics::DEFAULT_THEME);
+            $paths['parent'][]                = $defaultThemePath;
+            $paths[self::TWIG_MAIN_NAMESPACE] = $defaultThemePath;
 
             $this->view = new CustomTwig($paths, [
                 'cache'       => ROOT_PATH . Statics::THEME_CACHE_DIR,
@@ -204,11 +164,61 @@ class TemplateRenderService {
                 $this->view->getEnvironment()->enableDebug();
             }
 
-
             $this->view->getEnvironment()->addExtension(new Twig_Extension_Debug());
             $this->view->getEnvironment()->addExtension(new TwigOforgeDebugExtension());
         }
 
         return $this->view;
     }
+
+    /**
+     * Send a JSON response
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param array $data
+     *
+     * @return Response
+     */
+    private function renderJson(Request $request, Response $response, array $data) {
+        return $response->withHeader('Content-Type', 'application/json')->withJson($data);
+    }
+
+    /**
+     * Send the response through the Twig Engine
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param string $template
+     * @param array $data
+     *
+     * @return ResponseInterface
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws ServiceNotFoundException
+     * @throws Twig_Error_Loader
+     * @throws Twig_Error_Runtime
+     * @throws Twig_Error_Syntax
+     * @throws TemplateNotFoundException
+     */
+    private function renderTemplate(Request $request, Response $response, string $template, array $data) {
+        return $this->View()->render($response, $template, $data);
+    }
+
+    /**
+     * Check if the template exists
+     *
+     * @param $template
+     *
+     * @return bool
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws ServiceNotFoundException
+     * @throws Twig_Error_Loader
+     * @throws TemplateNotFoundException
+     */
+    private function hasTemplate($template) : bool {
+        return $this->View()->hasTemplate($template);
+    }
+
 }

--- a/Engine/Modules/TemplateEngine/Extensions/Bootstrap.php
+++ b/Engine/Modules/TemplateEngine/Extensions/Bootstrap.php
@@ -1,29 +1,39 @@
 <?php
+
 namespace Oforge\Engine\Modules\TemplateEngine\Extensions;
 
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 use Oforge\Engine\Modules\Core\Abstracts\AbstractBootstrap;
+use Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException;
+use Oforge\Engine\Modules\Core\Exceptions\TemplateNotFoundException;
 use Oforge\Engine\Modules\TemplateEngine\Core\Services\TemplateRenderService;
 use Oforge\Engine\Modules\TemplateEngine\Extensions\Twig\AccessExtension;
 use Oforge\Engine\Modules\TemplateEngine\Extensions\Twig\BackendExtension;
 use Oforge\Engine\Modules\TemplateEngine\Extensions\Twig\SlimExtension;
 use Oforge\Engine\Modules\TemplateEngine\Extensions\Twig\TokenExtension;
+use Twig_Error_Loader;
 
+/**
+ * Class Bootstrap
+ *
+ * @package Oforge\Engine\Modules\TemplateEngine\Extensions
+ */
 class Bootstrap extends AbstractBootstrap {
     /**
      * Bootstrap constructor.
      */
     public function __construct() {
-
     }
-    
+
     /**
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException
-     * @throws \Twig_Error_Loader
+     * @throws ORMException
+     * @throws OptimisticLockException
+     * @throws ServiceNotFoundException
+     * @throws TemplateNotFoundException
+     * @throws Twig_Error_Loader
      */
-    public function activate()
-    {
+    public function activate() {
         /**
          * @var $templateRenderer TemplateRenderService
          */

--- a/Engine/Modules/TemplateEngine/Extensions/Twig/AccessExtension.php
+++ b/Engine/Modules/TemplateEngine/Extensions/Twig/AccessExtension.php
@@ -8,8 +8,10 @@
 
 namespace Oforge\Engine\Modules\TemplateEngine\Extensions\Twig;
 
+use Doctrine\ORM\ORMException;
 use Oforge\Engine\Modules\Core\Exceptions\ConfigElementNotFoundException;
 use Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException;
+use Oforge\Engine\Modules\Core\Helper\ArrayHelper;
 use Oforge\Engine\Modules\Core\Services\ConfigService;
 use Oforge\Engine\Modules\I18n\Helper\I18N;
 use Twig_Extension;
@@ -28,12 +30,53 @@ class AccessExtension extends Twig_Extension implements Twig_ExtensionInterface 
      */
     public function getFunctions() {
         return [
-            new Twig_Function('config', [$this, 'getConfig'], ['is_safe' => ['html']]),
+            new Twig_Function('config', [$this, 'getConfig'], [
+                'is_safe' => ['html'],
+            ]),
             new Twig_Function('i18n', [$this, 'getInternationalization'], [
                 'is_safe'       => ['html'],
                 'needs_context' => true,
             ]),
+            new Twig_Function('dotToNested', [$this, 'dotToNested'], [
+                'is_safe' => ['html'],
+            ]),
+            new Twig_Function('mergeRecursive', [$this, 'mergeRecursive'], [
+                'is_safe' => ['html'],
+            ]),
         ];
+    }
+
+    /** @inheritDoc */
+    public function getTests() {
+        return [
+            new \Twig_Test('array', [$this, 'isArray']),
+            new \Twig_Test('string', [$this, 'isString']),
+        ];
+    }
+
+    /**
+     * Convert array with keys in dot notation to nested arrays.
+     *
+     * @param array $array
+     *
+     * @return array
+     * @see ArrayHelper::dotToNested()
+     */
+    public function dotToNested(array $array) : array {
+        return ArrayHelper::dotToNested($array);
+    }
+
+    /**
+     * Merge array recursive.
+     *
+     * @param array $array1
+     * @param array $array2
+     *
+     * @return array
+     * @see ArrayHelper::mergeRecursive()
+     */
+    public function mergeRecursive(array $array1, array $array2) : array {
+        return ArrayHelper::mergeRecursive($array1, $array2);
     }
 
     /**
@@ -42,6 +85,7 @@ class AccessExtension extends Twig_Extension implements Twig_ExtensionInterface 
      * @return mixed|string
      * @throws ConfigElementNotFoundException
      * @throws ServiceNotFoundException
+     * @throws ORMException
      */
     public function getConfig(...$vars) {
         $result = '';
@@ -70,6 +114,28 @@ class AccessExtension extends Twig_Extension implements Twig_ExtensionInterface 
         }
 
         return $result;
+    }
+
+    /**
+     * Twig test '... is array' to php is_array.
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function isArray($value) {
+        return is_array($value);
+    }
+
+    /**
+     * Twig test '... is string' to php is_string.
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function isString($value) {
+        return is_string($value);
     }
 
 }

--- a/Engine/Modules/TemplateEngine/Extensions/Twig/SlimExtension.php
+++ b/Engine/Modules/TemplateEngine/Extensions/Twig/SlimExtension.php
@@ -8,6 +8,8 @@
 
 namespace Oforge\Engine\Modules\TemplateEngine\Extensions\Twig;
 
+use Exception;
+use Oforge\Engine\Modules\Core\Helper\ArrayHelper;
 use Slim\Router;
 use Twig_Extension;
 use Twig_Function;
@@ -26,22 +28,13 @@ class SlimExtension extends Twig_Extension {
      */
     public function getFunctions() {
         return [
-            new Twig_Function('url', [$this, 'getSlimUrl'], ['is_safe' => ['html']]),
+            new Twig_Function('url', [$this, 'getSlimUrl'], [
+                'is_safe' => ['html'],
+            ]),
         ];
     }
 
     /**
-     * @inheritDoc
-     */
-    public function getTests() {
-        return [
-            new \Twig_Test('array', [$this, 'isArray']),
-            new \Twig_Test('string', [$this, 'isString']),
-        ];
-    }
-
-    /**
-     *
      * @param mixed ...$vars
      *
      * @return string
@@ -50,44 +43,16 @@ class SlimExtension extends Twig_Extension {
         if (!isset($this->router)) {
             $this->router = Oforge()->App()->getContainer()->get('router');
         }
-        switch (count($vars)) {
-            case 1:
-                $result = $this->router->pathFor($vars[0]);
-                break;
-            case 2:
-                $result = $this->router->pathFor($vars[0], $vars[1]);
-                break;
-            case 3:
-                $result = $this->router->pathFor($vars[0], $vars[1], $vars[2]);
-                break;
-            default:
-                $result = '';
-                break;
+        $name        = ArrayHelper::get($vars, 0);
+        $namedParams = ArrayHelper::get($vars, 1, []);
+        $queryParams = ArrayHelper::get($vars, 2, []);
+        try {
+            $result = $this->router->pathFor($name, $namedParams, $queryParams);
+        } catch (Exception $e) {
+            $result = '';
         }
 
         return $result;
-    }
-
-    /**
-     * Slim test '... is array' to php is_array.
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    public function isArray($value) {
-        return is_array($value);
-    }
-
-    /**
-     * Slim test '... is string' to php is_string.
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    public function isString($value) {
-        return is_string($value);
     }
 
 }

--- a/Themes/Base/Backend/CRUD/Components/ViewBase.twig
+++ b/Themes/Base/Backend/CRUD/Components/ViewBase.twig
@@ -1,9 +1,7 @@
 {% extends 'Backend/Master/Index.twig' %}
-{% set meta = meta|default({})|merge({
-    page: meta.page|default({})|merge({
-        favoriteButton: false,
-    })
-}) %}
+{% set meta = mergeRecursive(meta|default({}), dotToNested({
+    'meta.page.favoriteButton': false,
+})) %}
 {% set crud = crud|default({})|merge({
     baseRouteName: meta.route.name|split('_')|slice(0, -1)|join('_')
 }) %}

--- a/Themes/Base/Frontend/Layout.twig
+++ b/Themes/Base/Frontend/Layout.twig
@@ -1,7 +1,7 @@
 {#
     This file is a helper file for extending the layout of a theme.
-    The variable template_layout can be changed in the admin backend and will be set to Default in the TemplateRenderService
+    The variable meta.template.layout can be changed in the admin backend and will be set to Default in the TemplateRenderService
     if no layout is defined. This helps template developers to easily extend the base theme.
     You just have to extend '@parent/Frontend/Layout.twig' and define the layout in the admin backend.
 #}
-{% extends 'Frontend/Layouts/' ~ template_layout ~ '.twig' %}
+{% extends 'Frontend/Layouts/' ~ meta.template.layout|default('Default') ~ '.twig' %}


### PR DESCRIPTION
- move view data 'template.path' to meta.template.path
- move view data 'template_layout' to meta.template.layout
- add ArrayHelper methods for dot notation based keys
- change View#asssign and View#get to dot based use
- add TwigExtension functions dotToNested and mergeRecursive