### PR TITLE
Allow i18n-snippets to have only a default value in only one language.

### DIFF
--- a/Engine/Modules/I18n/Helper/I18N.php
+++ b/Engine/Modules/I18n/Helper/I18N.php
@@ -43,6 +43,8 @@ class I18N {
                 $result = null;
                 if (isset($defaultValue[$language])) {
                     $result = self::$i18nService->get($key, $language, $defaultValue[$language]);
+                } else {
+                    $result = self::$i18nService->get($key, $language, null);
                 }
                 foreach ($defaultValue as $languageIso => $languageDefaultValue) {
                     if ($language === $languageIso) {


### PR DESCRIPTION
There was a problem when trying to use i18n-snippets which only have a default value in one language. 
E.g. using a snippet with {{ i18n('frontend_success', {'en' : 'Success'}) }} would always return the english value although a German Translation is stored in the database.

Previously you would have to assign a default value to any language within the template. In this example {{ i18n('frontend_success', {'en' : 'Success', 'de' : 'Erfolg', it: 'Successo'}) }}, even if you don't speak the languages or don't even know which languages will be available at some point.