### PR TITLE
Add Helper in core and media modules

### DIFF
--- a/Engine/Modules/Core/Helper/EmbeddedUrlHelper.php
+++ b/Engine/Modules/Core/Helper/EmbeddedUrlHelper.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Oforge\Engine\Modules\Core\Helper;
+
+/**
+ * Class EmbeddedUrlTransformer
+ *
+ * @package Oforge\Engine\Modules\Core\Helper
+ */
+class EmbeddedUrlHelper
+{
+    private static $baseUrl;
+
+    private function __construct()
+    {
+    }
+
+    public static function resolveInArray(array &$data, string $key) : void
+    {
+        if ( !isset($data[$key]) || empty($data[$key])) {
+            return;
+        }
+        $data[$key] = self::resolveInValue($data[$key]);
+    }
+
+    public static function resolveInValue(?string $text) : string
+    {
+        if (empty($text)) {
+            return $text;
+        }
+        if ( !isset(self::$baseUrl)) {
+            self::$baseUrl = RouteHelper::getFullUrl('/');;
+        }
+        $newValue = preg_replace('/((src|href)\s*=\s*[\'"])\/(var\/public\/.*)([\'"])/m', '$1' . self::$baseUrl . '$3$4', $text);
+
+        return ($newValue ?? $text);
+    }
+
+}

--- a/Engine/Modules/Media/Helper/EmbeddedImageHelper.php
+++ b/Engine/Modules/Media/Helper/EmbeddedImageHelper.php
@@ -51,19 +51,24 @@ class EmbeddedImageHelper
                 $quoteStart = trim($matches[3]);
                 $quoteEnd   = trim($matches[6]);
 
-                $imagePaths = ImageHelper::resolveSingle($imagePath, $size);
+                $imagePaths = ImageHelper::compressSingle($imagePath, $size);
                 if ($imagePaths === null) {
                     return $matches[0];
                 }
                 if (is_array($imagePaths)) {
                     $sources = '';
+                    $minBreakpoint = 999999999;
                     foreach ($imagePaths as $breakpoint => $url) {
-                        $sources .= "<source srcset=" . $quoteStart . $url . $quoteEnd . " media=" . $quoteStart . "(min-width: " . $breakpoint . "px)" . $quoteEnd . "/>";
+                        if (is_numeric($breakpoint)) {
+                            $minBreakpoint = min($minBreakpoint, $breakpoint);
+                        }
+                        $sources .= '<source srcset=' . $quoteStart . $url . $quoteEnd . ' media=' . $quoteStart . '(min-width: ' . $breakpoint . 'px)' . $quoteEnd . '/>';
                     }
+                    $sources .= '<img src=' . $quoteStart . $imagePaths[$minBreakpoint] . $quoteEnd . '/>';
 
-                    return "<picture$attributes>$sources</picture>";
+                    return '<picture' . $attributes . '>' . $sources . '</picture>';
                 } else {
-                    return "<img" . $attributes . " src=" . $quoteStart . $imagePaths . $quoteEnd . "/>";
+                    return '<img' . $attributes . ' src=' . $quoteStart . $imagePaths . $quoteEnd . '/>';
                 }
             },
             $text

--- a/Engine/Modules/Media/Helper/EmbeddedImageHelper.php
+++ b/Engine/Modules/Media/Helper/EmbeddedImageHelper.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Oforge\Engine\Modules\Media\Helper;
+
+/**
+ * Class EmbeddedMediaHelper
+ *
+ * @package Oforge\Engine\Modules\Media\Helper
+ */
+class EmbeddedImageHelper
+{
+    private function __construct()
+    {
+    }
+
+    public static function resolveInArray(array &$data, string $key, $size = 0)
+    {
+        if ( !isset($data[$key]) || empty($data[$key])) {
+            return;
+        }
+        $data[$key] = self::resolveSingle($data[$key], $size);
+    }
+
+    /**
+     * @param string|null $text
+     * @param int|array<string, int> $size If array, img tag will be replaced by picture tag
+     *
+     * @return string
+     */
+    public static function resolveSingle(?string $text, $size = 0) : string
+    {
+        if (empty($text)) {
+            return $text;
+        }
+        // Array
+        // (
+        //     [0] => <img class="asd" src="/var/public/images/path" id=asd>
+        //     [1] => <img class="asd" src="
+        //     [2] =>  class="asd"
+        //     [3] => "
+        //     [4] => var/public/images/path
+        //     [5] => " id=asd>
+        //     [6] => "
+        //     [7] =>  id=asd
+        // )
+        $newText = preg_replace_callback(
+            '/(<img(.*?)src=([\'"]))(\/var\/public\/images\/.*?)(([\'"])(.*?)\/?>)/m',
+            function (array $matches) use ($size) {
+                $imagePath  = trim($matches[4]);
+                $attributes = rtrim(' ' . trim($matches[2]) . ' ' . trim($matches[7]));
+                $quoteStart = trim($matches[3]);
+                $quoteEnd   = trim($matches[6]);
+
+                $imagePaths = ImageHelper::resolveSingle($imagePath, $size);
+                if ($imagePaths === null) {
+                    return $matches[0];
+                }
+                if (is_array($imagePaths)) {
+                    $sources = '';
+                    foreach ($imagePaths as $breakpoint => $url) {
+                        $sources .= "<source srcset=" . $quoteStart . $url . $quoteEnd . " media=" . $quoteStart . "(min-width: " . $breakpoint . "px)" . $quoteEnd . "/>";
+                    }
+
+                    return "<picture$attributes>$sources</picture>";
+                } else {
+                    return "<img" . $attributes . " src=" . $quoteStart . $imagePaths . $quoteEnd . "/>";
+                }
+            },
+            $text
+        );
+
+        return ($newText ?? $text);
+    }
+
+}

--- a/Engine/Modules/Media/Helper/ImageHelper.php
+++ b/Engine/Modules/Media/Helper/ImageHelper.php
@@ -23,12 +23,12 @@ class ImageHelper
     {
     }
 
-    public static function resolveInArray(array &$data, string $key, $size = 0, bool $addOriginalImageUrl = ImageHelper::DEFAULT_ADD_ORIGINAL_IMAGE_URL) : void
+    public static function compressInArray(array &$data, string $key, $size = 0, bool $addOriginalImageUrl = ImageHelper::DEFAULT_ADD_ORIGINAL_IMAGE_URL) : void
     {
         if ( !isset($data[$key]) || empty($data[$key])) {
             return;
         }
-        $result = self::resolveSingle($data[$key], $size, $addOriginalImageUrl);
+        $result = self::compressSingle($data[$key], $size, $addOriginalImageUrl);
         if ($result !== null) {
             $data[$key] = $result;
         }
@@ -41,7 +41,7 @@ class ImageHelper
      *
      * @return array|string|null Returns null on error, full url string for int $size, or responsive array.
      */
-    public static function resolveSingle($idOrPath, $size = 0, bool $addOriginalImageUrl = ImageHelper::DEFAULT_ADD_ORIGINAL_IMAGE_URL)
+    public static function compressSingle($idOrPath, $size = 0, bool $addOriginalImageUrl = ImageHelper::DEFAULT_ADD_ORIGINAL_IMAGE_URL)
     {
         if (self::$imageCompressService === null) {
             try {
@@ -108,7 +108,7 @@ class ImageHelper
             $relativePath .= (strpos($relativePath, '?') === false ? '?' : '&') . 'size=' . $maxSize;
         }
 
-        return RouteHelper::getFullUrl(str_replace(" ", "%20", $relativePath));
+        return RouteHelper::getFullUrl(str_replace(' ', '%20', $relativePath));
     }
 
 }

--- a/Engine/Modules/Media/Helper/ImageHelper.php
+++ b/Engine/Modules/Media/Helper/ImageHelper.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Oforge\Engine\Modules\Media\Helper;
+
+use Exception;
+use Oforge\Engine\Modules\Core\Exceptions\ServiceNotFoundException;
+use Oforge\Engine\Modules\Core\Helper\RouteHelper;
+use Oforge\Engine\Modules\Media\Services\ImageCompressService;
+
+/**
+ * Class ImageHelper
+ *
+ * @package CMS\Helper
+ */
+class ImageHelper
+{
+    public const DEFAULT_ADD_ORIGINAL_IMAGE_URL = false;
+    private const DEBUG_SIZE = false;
+    /** @var ImageCompressService $imageCompressService */
+    private static $imageCompressService;
+
+    private function __construct()
+    {
+    }
+
+    public static function resolveInArray(array &$data, string $key, $size = 0, bool $addOriginalImageUrl = ImageHelper::DEFAULT_ADD_ORIGINAL_IMAGE_URL) : void
+    {
+        if ( !isset($data[$key]) || empty($data[$key])) {
+            return;
+        }
+        $result = self::resolveSingle($data[$key], $size, $addOriginalImageUrl);
+        if ($result !== null) {
+            $data[$key] = $result;
+        }
+    }
+
+    /**
+     * @param int|string $idOrPath
+     * @param int $size
+     * @param bool $addOriginalImageUrl
+     *
+     * @return array|string|null Returns null on error, full url string for int $size, or responsive array.
+     */
+    public static function resolveSingle($idOrPath, $size = 0, bool $addOriginalImageUrl = ImageHelper::DEFAULT_ADD_ORIGINAL_IMAGE_URL)
+    {
+        if (self::$imageCompressService === null) {
+            try {
+                self::$imageCompressService = Oforge()->Services()->get('image.compress');
+            } catch (ServiceNotFoundException $exception) {
+                Oforge()->Logger()->logException($exception);
+
+                return null;
+            }
+        }
+        $result = [];
+        if ($addOriginalImageUrl) {
+            try {
+                $relativePath = self::$imageCompressService->getPath($idOrPath, 0);
+                if ($relativePath !== null) {
+                    $result['full'] = self::finaliseUrl($relativePath, 0);
+                }
+            } catch (Exception $exception) {
+                Oforge()->Logger()->logException($exception);
+            }
+        }
+        if (is_array($size)) {
+            foreach ($size as $breakpoint => $maxSize) {
+                try {
+                    $relativePath = self::$imageCompressService->getPath($idOrPath, $maxSize);
+                    if ($relativePath !== null) {
+                        $result[$breakpoint] = self::finaliseUrl($relativePath, $maxSize);
+                    }
+                } catch (Exception $exception) {
+                    Oforge()->Logger()->logException($exception);
+                }
+            }
+        } else {
+            try {
+                $relativePath = self::$imageCompressService->getPath($idOrPath, $size);
+                if ($relativePath === null) {
+                    return null;
+                }
+                $fullUrl = self::finaliseUrl($relativePath, $size);
+                if ($addOriginalImageUrl) {
+                    $result[$size] = $fullUrl;
+                } else {
+                    return $fullUrl;
+                }
+            } catch (Exception $exception) {
+                Oforge()->Logger()->logException($exception);
+
+                return null;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $relativePath
+     * @param int $maxSize
+     *
+     * @return string
+     */
+    private static function finaliseUrl(string $relativePath, int $maxSize) : string
+    {
+        if (self::DEBUG_SIZE) {
+            $relativePath .= (strpos($relativePath, '?') === false ? '?' : '&') . 'size=' . $maxSize;
+        }
+
+        return RouteHelper::getFullUrl(str_replace(" ", "%20", $relativePath));
+    }
+
+}


### PR DESCRIPTION
- Core EmbeddedUrlHelper:
  Makes relative urls (starting with /var/public) in text absolute (prefixing with host and baseurl)
- Media ImageHelper:
  Create compressed full path or compressed full paths for breakpoints (used in among others CMS, EMV)
- Media EmbeddedImageHelper:
  Replace img src with relative original path in text with compressed full path or whole img tag with picture tag (replacing based of size parameter)